### PR TITLE
fix(ci): isolate tests and migration checks from global production secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,10 @@ jobs:
           name: run tests
           environment:
             SECRET_KEY: 123456-TEST
+            MYSQL_HOST: 127.0.0.1
+            MYSQL_DB_NAME: test_test_db
+            MYSQL_USER: user
+            MYSQL_PWD: user
           command: |
             uv run pytest --junitxml=test-reports/test-results.xml --cov=. --cov-report=xml --cov-report=html
       - store_test_results:
@@ -316,6 +320,12 @@ jobs:
   check_migrations:
     docker:
       - image: cimg/base:stable
+      - image: cimg/mysql:9.6
+        command: [ --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --default-storage-engine=InnoDB ]
+        environment:
+          MYSQL_DATABASE: test_test_db
+          MYSQL_USER: user
+          MYSQL_PASSWORD: user
     steps:
       - setup_remote_docker:
           version: 20.10.24
@@ -326,10 +336,11 @@ jobs:
           command: |
             docker load -i /tmp/docker-images/backend.tar
             docker run --rm \
-              -e MYSQL_HOST="$MYSQL_HOST" \
-              -e MYSQL_DB_NAME="$MYSQL_DB_NAME" \
-              -e MYSQL_USER="$MYSQL_USER" \
-              -e MYSQL_PWD="$MYSQL_PWD" \
+              --network host \
+              -e MYSQL_HOST="127.0.0.1" \
+              -e MYSQL_DB_NAME="test_test_db" \
+              -e MYSQL_USER="user" \
+              -e MYSQL_PWD="user" \
               backend:latest \
               bash -c "set -e && python manage.py check && python manage.py makemigrations --check --dry-run && python manage.py migrate --plan"
 


### PR DESCRIPTION
This PR fixes a critical pipeline failure where global project environment variables (production secrets) were overriding local test database configurations.

- **python job**: Explicitly set local environment variables to ensure pytest runs against the local service.
- **check_migrations job**: Added a local MySQL service and configured it to be self-contained.