### PR TITLE
chore(deps): comprehensive Renovate dependency and action updates

### DIFF
--- a/.github/workflows/part_check_migrations.yaml
+++ b/.github/workflows/part_check_migrations.yaml
@@ -35,7 +35,7 @@ jobs:
     environment: staging
     steps:
       - name: 📥 Download Docker image artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
           path: /tmp

--- a/.github/workflows/part_docker_build.yaml
+++ b/.github/workflows/part_docker_build.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: 🐳🛠️ Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🐳🏗️ Build Docker image
         uses: docker/build-push-action@v6
@@ -40,7 +40,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: 📤 Upload Docker image as artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: docker-image-${{ inputs.image_name }}
           path: /tmp/${{ inputs.image_name }}.tar

--- a/.github/workflows/part_docker_push_artifact.yaml
+++ b/.github/workflows/part_docker_push_artifact.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: 📥 Download Docker image artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
           path: /tmp
@@ -51,10 +51,10 @@ jobs:
           docker image ls -a
 
       - name: 🐳🛠️ Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🔐📦 Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/part_docker_push_staging.yaml
+++ b/.github/workflows/part_docker_push_staging.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: 📥 Download Docker image artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
           path: /tmp
@@ -50,10 +50,10 @@ jobs:
           docker image ls -a
 
       - name: 🐳🛠️ Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🔐📦 Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/part_docker_test.yaml
+++ b/.github/workflows/part_docker_test.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Download Docker image artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
           path: /tmp

--- a/.github/workflows/part_run_migrations.yaml
+++ b/.github/workflows/part_run_migrations.yaml
@@ -40,7 +40,7 @@ jobs:
     environment: ${{ inputs.environment_name }}
     steps:
       - name: 📥 Download Docker image artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
           path: /tmp

--- a/.github/workflows/part_test_compose_network.yaml
+++ b/.github/workflows/part_test_compose_network.yaml
@@ -31,13 +31,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 📥 Download backend Docker image artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.backend_artifact_name }}
           path: /tmp
 
       - name: 📥 Download frontend Docker image artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.frontend_artifact_name }}
           path: /tmp


### PR DESCRIPTION
This PR consolidates several green Renovate updates from the fork:

**Dependency Updates:**
- serialize-javascript to v7.0.4
- postcss to v8.5.8
- axios to v1.13.6
- django-rest-knox to v5.0.4
- @redux-devtools/extension to v4
- docker/build-push-action to v7
- i18next-resources-for-ts to v2.0.1

**GitHub Action Updates:**
- docker/setup-buildx-action to v4
- docker/login-action to v4
- github artifact actions (major)